### PR TITLE
Update compatibility

### DIFF
--- a/lara.xcodeproj/project.pbxproj
+++ b/lara.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -351,7 +351,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/lara/lara.swift
+++ b/lara/lara.swift
@@ -16,13 +16,15 @@ struct lara: App {
     var body: some Scene {
         WindowGroup {
             TabView {
-                Tab("lara", systemImage: "ant.fill") {
-                    ContentView()
-                }
+                ContentView()
+                    .tabItem {
+                        Label("lara", systemImage: "ant.fill")
+                    }
 
-                Tab("Logs", systemImage: "text.document.fill") {
-                    LogsView(logger: globallogger)
-                }
+                LogsView(logger: globallogger)
+                    .tabItem {
+                        Label("Logs", systemImage: "text.document.fill")
+                    }
             }
             .onAppear {
                 init_offsets()


### PR DESCRIPTION
Change tabs to support pre iOS 18.0.
Tested on a iPhone 15 pro max, iOS 17.5 font changing worked just fine.
See images below


<img width="562" height="1230" alt="IMG_0513" src="https://github.com/user-attachments/assets/85f475f8-d264-4095-9cb0-a07de4448b17" />
<img width="562" height="1230" alt="IMG_0513" src="https://github.com/user-attachments/assets/8386b8b8-679c-4c1f-ba46-6d29f6ef671a" />