### PR TITLE
Fix version date format and update size

### DIFF
--- a/source.json
+++ b/source.json
@@ -21,8 +21,8 @@
       "versions": [
         {
           "version": "1.1",
-          "date": "19.5.2025",
-          "size": 2000,
+          "date": "2025-05-19",
+          "size": 3450675,
           "downloadURL": "https://github.com/rooootdev/lara/releases/download/latest/lara.ipa",
           "localizedDescription": "",
           "minOSVersion": "15.0"


### PR DESCRIPTION
Fixes source.json to be AltStore/SideStore compliant.

- date: changed "19.5.2025" → "2025-05-19" (ISO 8601, required by AltStore spec)
- size: changed 2000 → 3450675 (actual IPA size in bytes, 3.29 MB)