### PR TITLE
2 Fixes (PerformanceHUD and Respring) also fix build

### DIFF
--- a/lara/classes/laramgr.swift
+++ b/lara/classes/laramgr.swift
@@ -92,6 +92,7 @@ final class laramgr: ObservableObject {
     @Published var sbxfailed: Bool = false
     @Published var sbxrunning: Bool = false
     @Published var rcready: Bool = false
+    @Published var showRespringView: Bool = false
     
     var sbProc: RemoteCall?
     

--- a/lara/views/ContentView.swift
+++ b/lara/views/ContentView.swift
@@ -446,12 +446,13 @@ struct ContentView: View {
                         }
 
                         Button("Respring") {
-                            .overlay {
-                                if mgr.showRespringView {
-                                    RespringView()
-                                        .brightness(-1.0)
-                                        .ignoresSafeArea()
-                                }
+                            mgr.showRespringView = true
+                        }
+                        .fullScreenCover(isPresented: $mgr.showRespringView) {
+                            if mgr.showRespringView {
+                                RespringView()
+                                    .brightness(-1.0)
+                                    .ignoresSafeArea()
                             }
                         }
 

--- a/lara/views/EditorView.swift
+++ b/lara/views/EditorView.swift
@@ -131,12 +131,13 @@ struct EditorView: View {
             .alert("Done", isPresented: .constant(alert != nil)) {
                 Button("Cancel") { alert = nil }
                 Button("Respring") {
-                    .overlay {
-                        if mgr.showRespringView {
-                            RespringView()
-                                .brightness(-1.0)
-                                .ignoresSafeArea()
-                        }
+                    mgr.showRespringView = true
+                }
+                .fullScreenCover(isPresented: $mgr.showRespringView) {
+                    if mgr.showRespringView {
+                        RespringView()
+                            .brightness(-1.0)
+                            .ignoresSafeArea()
                     }
                 }
             } message: {

--- a/lara/views/FontPicker.swift
+++ b/lara/views/FontPicker.swift
@@ -129,12 +129,13 @@ struct FontPicker: View {
                         .font(.system(size: 13, design: .monospaced))
                     
                     Button("Respring") {
-                        .overlay {
-                            if mgr.showRespringView {
-                                RespringView()
-                                    .brightness(-1.0)
-                                    .ignoresSafeArea()
-                            }
+                        mgr.showRespringView = true
+                    }
+                    .fullScreenCover(isPresented: $mgr.showRespringView) {
+                        if mgr.showRespringView {
+                            RespringView()
+                                .brightness(-1.0)
+                                .ignoresSafeArea()
                         }
                     }
                 }

--- a/lara/views/RemoteView.swift
+++ b/lara/views/RemoteView.swift
@@ -11,7 +11,7 @@ struct RemoteView: View {
     @ObservedObject var mgr: laramgr
     @State private var running: Bool = false
     @State private var columns: Int = 5
-    @State private var performanceHUD: Int = 0
+    @State private var performanceHUD: Int = -1
     @AppStorage("rcdockunlimited") private var rcdockunlimited: Bool = false
 
     private var dockMaxColumns: Int { rcdockunlimited ? 50 : 10 }

--- a/lara/views/ToolsView.swift
+++ b/lara/views/ToolsView.swift
@@ -74,16 +74,15 @@ struct ToolsView: View {
             }
             
             Section {
-                Button {
-                    .overlay {
-                        if mgr.showRespringView {
-                            RespringView()
-                                .brightness(-1.0)
-                                .ignoresSafeArea()
-                        }
+                Button("Respring") {
+                    mgr.showRespringView = true
+                }
+                .fullScreenCover(isPresented: $mgr.showRespringView) {
+                    if mgr.showRespringView {
+                        RespringView()
+                            .brightness(-1.0)
+                            .ignoresSafeArea()
                     }
-                } label: {
-                    Text("Respring")
                 }
                 
                 HStack {


### PR DESCRIPTION
Fix PerformanceHUD starting at "Basic" instead of "Off"
Made Respring Fullscreen instead of Overlay so its a little more reliable

Tested on iPhone 14 (iOS 18.1 22B5045g)

I tested this and I dont see any issues
<img width="256" height="auto" alt="image" src="https://github.com/user-attachments/assets/ca595444-66ef-4f92-9bb2-e100b0f3f53c" />
<img width="256" height="auto" alt="image" src="https://github.com/user-attachments/assets/a601fc3e-4fd9-4f18-b1a7-bb0bd0bccdcf" />