### PR TITLE
EUEnabler: fix unknown type rc_euenabler_callback_t by importing headers

### DIFF
--- a/lara/kexploit/pe/rc.m
+++ b/lara/kexploit/pe/rc.m
@@ -19,6 +19,7 @@
 
 #import "RemoteCall.h"
 #import "PrivateAPI.h"
+#import "rc.h"
 
 int ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
 #define PT_DETACH       11


### PR DESCRIPTION
```text
/Users/runner/work/lara/lara/lara/kexploit/pe/rc.m:551:56: error: unknown type name 'rc_euenabler_callback_t'
  551 | void euenabler_override_country_code(RemoteCall *proc, rc_euenabler_callback_t callback) {
      |                                                        ^
1 error generated.
```