### PR TITLE
fix: selectedmethod not persisted in ContentView and SantanderView (@State → @AppStorage)

### DIFF
--- a/lara/views/ContentView.swift
+++ b/lara/views/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     @ObservedObject private var mgr = laramgr.shared
     @State private var hasoffsets = true
     @State private var showsettings = false
-    @State private var selectedmethod: method = .hybrid
+    @AppStorage("selectedmethod") private var selectedmethod: method = .hybrid
 
     var body: some View {
         NavigationStack {

--- a/lara/views/SantanderView.swift
+++ b/lara/views/SantanderView.swift
@@ -14,7 +14,7 @@ import QuickLook
 
 struct SantanderView: View {
     let startPath: String
-    @State private var selectedmethod: method = .sbx
+    @AppStorage("selectedmethod") private var selectedmethod: method = .hybrid
     @ObservedObject private var mgr = laramgr.shared
 
     init(startPath: String = "/") {


### PR DESCRIPTION
## Problem

`ContentView` and `SantanderView` both declare `selectedmethod` as `@State` with a hard-coded default, instead of `@AppStorage`. This means the VFS/SBX/Hybrid method the user picks in Settings is **never actually applied** in either view — they always use their default values.

```swift
// ContentView.swift:16 — always .hybrid, ignores Settings
@State private var selectedmethod: method = .hybrid

// SantanderView.swift:17 — always .sbx, ignores Settings
@State private var selectedmethod: method = .sbx
```

All other uses of this setting (`lara.swift`, `SettingsView.swift`, `AppsView.swift`) correctly use `@AppStorage("selectedmethod")`.

`SantanderView` even has an explicit `UserDefaults.didChangeNotification` workaround (`refreshSelectedMethod()`, lines 50–52) that compensates for the missing `@AppStorage` — confirming this was a known issue. With `@AppStorage` in place that workaround is now redundant but harmless; left for the maintainer to clean up.

## Fix

Change both declarations to `@AppStorage("selectedmethod")` with a consistent default of `.hybrid` (matching `lara.swift` and `SettingsView`).

## Verification

1. Install and open the app
2. Go to Settings → change Method to "VFS"
3. Return to the main tab
4. The step-sequence should now show "Initialise VFS" (not "Escape Sandbox")
5. Repeat with "SBX" — should show "Escape Sandbox"