### PR TITLE
fix: dispatch rcinitDaemon completion handler back to main queue

### DIFF
--- a/lara/classes/laramgr.swift
+++ b/lara/classes/laramgr.swift
@@ -509,8 +509,8 @@ final class laramgr: ObservableObject {
             }
             
             let proc = RemoteCall(process: process, useMigFilterBypass: migbypass)
-            completion?(proc)
-            
+            DispatchQueue.main.async { completion?(proc) }
+
             DispatchQueue.main.async {
                 guard let self = self else { return }
                 let success = proc != nil


### PR DESCRIPTION
## Problem

`rcinitDaemon` in `laramgr.swift` fires its `completion` callback on a background `DispatchQueue.global` queue:

```swift
DispatchQueue.global(qos: .userInitiated).async { [weak self] in
    // ...
    let proc = RemoteCall(process: process, useMigFilterBypass: migbypass)
    completion?(proc)   // ← background thread
    // ...
}
```

Every other completion callback in this file (`run`, `vfsinit`, `sbxescape`, `rcinit`) dispatches back to `DispatchQueue.main` before calling its completion. `rcinitDaemon` is the only one that doesn't.

Any caller that updates `@Published` properties or SwiftUI bindings from this completion will produce a **"Publishing changes from background threads is not allowed"** runtime warning on Xcode 15+, and can cause undefined state mutation behavior (race on `@Published` property observed from main thread).

## Fix

Wrap `completion?(proc)` in `DispatchQueue.main.async { }`, consistent with all other completion handlers in the file.

```swift
// Before
completion?(proc)

// After
DispatchQueue.main.async { completion?(proc) }
```

## Verification

Add a `rcinitDaemon` caller that updates a `@Published` var in the completion block. Before this fix: Xcode runtime warning logged. After: no warning.