### PR TITLE
Fix overriding user-set offsets

### DIFF
--- a/lara/kexploit/offsets.m
+++ b/lara/kexploit/offsets.m
@@ -300,10 +300,11 @@ void offsets_init(void) {
                             cpuFamily == CPUFAMILY_ARM_IBIZA ||  // M3
                             cpuFamily == CPUFAMILY_ARM_DONAN); // M4
     
-    uint64_t expected_t1sz_boot = (isA16Above || isMSeriesIpad) ? 0x11 : 0x19;
-    if (t1sz_boot != expected_t1sz_boot) {
-        t1sz_boot = expected_t1sz_boot;
-    }
+    // these checks will overide the user set offsets
+    // uint64_t expected_t1sz_boot = (isA16Above || isMSeriesIpad) ? 0x11 : 0x19;
+    // if (t1sz_boot != expected_t1sz_boot) {
+    //     t1sz_boot = expected_t1sz_boot;
+    // }
 
     gIsPACSupported = is_pac_supported();
     


### PR DESCRIPTION
Could be me, but everything around t1sz_boot seems unnecessarily complicated and fragile. Anyways, a PR added a check that overrode t1sz_boot if set to a different one by the user, so i just commented it out.