### PR TITLE
Fix Stash KRW primitives setting key

### DIFF
--- a/lara/kexploit/darksword.m
+++ b/lara/kexploit/darksword.m
@@ -134,7 +134,7 @@ static char kernel_process_name[PROCESS_MARKER_MAX_LEN];
 static char host_executable_name[PROCESS_MARKER_MAX_LEN];
 
 BOOL stashkrw(void) {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:@"stashkrw"];
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"stashKRW"];
 }
 
 static void addprocmarker(const char *marker) {


### PR DESCRIPTION
## Summary

Fix the UserDefaults key used by Darksword when checking whether `Stash KRW primitives` is enabled.

`SettingsView` currently stores the toggle with `@AppStorage("stashKRW")`, but `darksword.m` was still reading `"stashkrw"`. Since UserDefaults keys are case-sensitive, enabling the toggle in Settings did not affect the Darksword code path.

## Changes

- Update `stashkrw()` to read `"stashKRW"`, matching the Settings toggle.

## Testing

- Not run. This is a one-line defaults-key alignment fix.