### PR TITLE
Use MobileContainer metadata for file manager display names

### DIFF
--- a/lara/views/fm/SantanderView.swift
+++ b/lara/views/fm/SantanderView.swift
@@ -523,12 +523,14 @@ private struct santanderdirview: View {
                 Text(entry.display)
                     .foregroundColor(entry.name.hasPrefix(".") ? .gray : .primary)
                     .lineLimit(1)
+                    .truncationMode(.middle)
 
                 if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Text(entry.path)
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .lineLimit(1)
+                        .truncationMode(.middle)
                 }
             }
 
@@ -1005,17 +1007,13 @@ private enum santanderfs {
         do {
             let names = try fm.contentsOfDirectory(atPath: item.path)
             let mode = fmAppsDisplayMode(rawValue: UserDefaults.standard.string(forKey: "selectedFmAppsDisplayMode") ?? "") ?? .appName
-            let datadirs = [
-                "/private/var/mobile/Containers/Data/Application",
-                "/var/mobile/Containers/Data/Application"
-            ]
             let bundledirs = [
                 "/private/var/containers/Bundle/Application",
                 "/var/containers/Bundle/Application"
             ]
             var appnames: [String: String] = [:]
 
-            if mode == .appName && datadirs.contains(item.path) {
+            if mode == .appName {
                 appnames = appnamecache()
             }
 
@@ -1025,15 +1023,18 @@ private enum santanderfs {
                 fm.fileExists(atPath: full, isDirectory: &isdir)
                 var display = name
 
-                if (bundledirs + datadirs).contains(item.path) {
-                    if mode == .appName {
-                        if bundledirs.contains(item.path) {
-                            display = bundleappname(at: full) ?? name
-                        } else if let bundleid = bundleidforcontainer(at: full) {
+                if mode != .UUID, isdir.boolValue {
+                    if bundledirs.contains(item.path), mode == .appName {
+                        display = bundleappname(at: full) ?? name
+                    } else if let bundleid = bundleidforcontainer(at: full) {
+                        switch mode {
+                        case .appName:
                             display = appnames[bundleid] ?? bundleid
+                        case .bundleID:
+                            display = bundleid
+                        case .UUID:
+                            break
                         }
-                    } else if mode == .bundleID, let bundleid = bundleidforcontainer(at: full) {
-                        display = bundleid
                     }
                 }
 


### PR DESCRIPTION
## Summary

Improve file manager display names for MobileContainer-managed directories.

Previously, Santander only converted UUID directory names for a few hardcoded container paths such as app data and app bundle directories. Other MobileContainer-managed folders, such as App Groups under `/var/mobile/Containers/Shared/AppGroup`, were still shown as raw UUIDs.

This PR makes the file manager detect `.com.apple.mobile_container_manager.metadata.plist` for directory entries and use `MCMMetadataIdentifier` as the display name when available.

## Changes

- Use MobileContainer metadata to display identifiers for UUID container directories.
- Keep UUID display mode unchanged.
- Keep app bundle display name handling for `/var/containers/Bundle/Application`.
- In App Name mode, prefer the app name when it can be resolved, otherwise fall back to the metadata identifier.
- Use middle truncation for long file names and paths so both the beginning and end remain visible on small screens.

## Testing

Tested on an iPhone SE 3.

- App Group containers under `/var/mobile/Containers/Shared/AppGroup` now show identifiers instead of raw UUIDs.
- No noticeable listing slowdown was observed.
- Long names are truncated in the middle and remain easier to identify on a small screen.