### PR TITLE
Fix MobileGestalt duplicate section and unsafe VFS fallback

### DIFF
--- a/lara/classes/laramgr.swift
+++ b/lara/classes/laramgr.swift
@@ -351,7 +351,7 @@ final class laramgr: ObservableObject {
     }
     
     @discardableResult
-    func lara_overwritefile(target: String, source: String) -> (ok: Bool, message: String) {
+    func lara_overwritefile(target: String, source: String, fallback_vfs: Bool = true) -> (ok: Bool, message: String) {
         guard FileManager.default.fileExists(atPath: source) else {
             return (false, "source file not found: \(source)")
         }
@@ -371,6 +371,10 @@ final class laramgr: ObservableObject {
         if result.ok {
             return result
         }
+
+        guard fallback_vfs else {
+            return result
+        }
         
         guard vfsready else {
             return (false, result.message + " | vfs not ready")
@@ -381,9 +385,13 @@ final class laramgr: ObservableObject {
     }
     
     @discardableResult
-    func lara_overwritefile(target: String, data: Data) -> (ok: Bool, message: String) {
+    func lara_overwritefile(target: String, data: Data, fallback_vfs: Bool = true) -> (ok: Bool, message: String) {
         let result = sbxready ? sbxoverwrite(path: target, data: data) : (false, "sbx not ready")
         if result.0 {
+            return result
+        }
+
+        guard fallback_vfs else {
             return result
         }
         

--- a/lara/views/tweaks/mobilegestalt/GestaltView.swift
+++ b/lara/views/tweaks/mobilegestalt/GestaltView.swift
@@ -433,7 +433,7 @@ struct GestaltView: View {
             
             // bro please dont bootloop
             let mgData = try verifyPlist(mgCurrentDict, targetPath: mgCurrentPath)
-            let result = mgr.lara_overwritefile(target: mgCurrentPath, data: mgData)
+            let result = mgr.lara_overwritefile(target: mgCurrentPath, data: mgData, fallback_vfs: false)
             
             if result.ok {
                 Alertinator.shared.alert(title: "Successfully applied MobileGestalt!", body: "Respring to see any changes", actionLabel: "Respring", action: { mgr.respring() })

--- a/lara/views/tweaks/mobilegestalt/GestaltView.swift
+++ b/lara/views/tweaks/mobilegestalt/GestaltView.swift
@@ -287,56 +287,7 @@ struct GestaltView: View {
                 } header: {
                     HeaderLabel(text: "SpringBoard", icon: "gear")
                 }
-                
-                Section {
-                    PlainToggle(
-                        text: "Disable Lock After Respring",
-                        icon: "lock.open",
-                        isOn: nuggetbinding(
-                            "SBDontLockAfterCrash",
-                            path: fileloc.springboard.rawValue
-                        )
-                    )
 
-                    PlainToggle(
-                        text: "Disable Low Battery Alerts",
-                        icon: "battery.25",
-                        isOn: nuggetbinding(
-                            "SBHideLowPowerAlerts",
-                            path: fileloc.springboard.rawValue
-                        )
-                    )
-
-                    PlainToggle(
-                        text: "Show Dynamic Island in Screenshots",
-                        icon: "camera",
-                        isOn: nuggetbinding(
-                            "SBAlwaysShowSystemApertureInSnapshots",
-                            path: fileloc.springboard.rawValue
-                        )
-                    )
-
-                    PlainToggle(
-                        text: "Play Sound on Paste",
-                        icon: "speaker.wave.2",
-                        isOn: nuggetbinding(
-                            "PlaySoundOnPaste",
-                            path: fileloc.pasteboard.rawValue
-                        )
-                    )
-
-                    PlainToggle(
-                        text: "System Paste Notifications",
-                        icon: "doc.on.clipboard",
-                        isOn: nuggetbinding(
-                            "AnnounceAllPastes",
-                            path: fileloc.pasteboard.rawValue
-                        )
-                    )
-                } header: {
-                    HeaderLabel(text: "Internal", icon: "ant")
-                }
-                
                 Section {
                     PlainToggle(
                         text: "Metal HUD Debug",


### PR DESCRIPTION
## Summary
- Remove a duplicated MobileGestalt section labeled `Internal`.
- Add a `fallback_vfs` option to `lara_overwritefile`, defaulting to `true` so existing callers keep the same behavior.
- Disable VFS fallback specifically for MobileGestalt writes.

## Why
The duplicated `Internal` section contained the same SpringBoard/Pasteboard toggles already shown under `SpringBoard`.

MobileGestalt writes are sensitive to file size changes. The sandbox overwrite path opens the file with `O_TRUNC`, so it can safely replace the plist with a different-sized serialized plist. The VFS overwrite fallback cannot safely resize the target file: it rejects larger sources and zero-fills trailing bytes for smaller sources. If sandbox overwrite fails and MobileGestalt falls back to VFS, the plist can become corrupted.

This keeps VFS fallback enabled by default for other overwrite users, but prevents it for MobileGestalt.

## Testing
- Tested on iPhone 13 Pro Max running iOS 17.3.1.
- Verified the MobileGestalt page no longer shows the duplicated `Internal` section.
- Verified MobileGestalt apply succeeds through the sandbox overwrite path without using VFS fallback.