### PR TITLE
Fix OTA Update & Screen Time status persistence after app reinstall

### DIFF
--- a/lara/views/tweaks/OTAView.swift
+++ b/lara/views/tweaks/OTAView.swift
@@ -51,18 +51,40 @@ struct OTAView: View {
                     }
                 }
                 .disabled(isWorking || !otaDisabled)
-
-                Button("Respring") {
-                    mgr.respring()
-                }
-                .disabled(isWorking)
             }
         }
         .navigationTitle("OTA Updates")
+        .onAppear {
+            if !otaDisabled {
+                syncStateFromPlist()
+            }
+        }
         .alert("Result", isPresented: .constant(lastResult != nil)) {
             Button("OK") { lastResult = nil }
         } message: {
             Text(lastResult ?? "")
+        }
+    }
+
+    private func syncStateFromPlist() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let plistPath = "/private/var/db/com.apple.xpc.launchd/disabled.plist"
+            let daemonLabels = [
+                "com.apple.mobile.softwareupdated",
+                "com.apple.OTATaskingAgent",
+                "com.apple.softwareupdateservicesd",
+                "com.apple.mobile.NRDUpdated",
+            ]
+            guard let data = NSData(contentsOfFile: plistPath) as Data?,
+                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] else {
+                return
+            }
+            let allDisabled = daemonLabels.allSatisfy { (plist[$0] as? Bool) == true }
+            if allDisabled {
+                DispatchQueue.main.async {
+                    otaDisabled = true
+                }
+            }
         }
     }
 

--- a/lara/views/tweaks/ScreenTimeView.swift
+++ b/lara/views/tweaks/ScreenTimeView.swift
@@ -80,18 +80,38 @@ struct ScreenTimeView: View {
                     }
                 }
                 .disabled(isWorking || !screenTimeDisabled)
-
-                Button("Respring") {
-                    mgr.respring()
-                }
-                .disabled(isWorking)
             }
         }
         .navigationTitle("Screen Time")
+        .onAppear {
+            if !screenTimeDisabled {
+                syncStateFromPlist()
+            }
+        }
         .alert("Result", isPresented: .constant(lastResult != nil)) {
             Button("OK") { lastResult = nil }
         } message: {
             Text(lastResult ?? "")
+        }
+    }
+
+    private func syncStateFromPlist() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let plistPath = "/private/var/db/com.apple.xpc.launchd/disabled.plist"
+            let daemonLabels = [
+                "com.apple.ScreenTimeAgent",
+                "com.apple.UsageTrackingAgent",
+            ]
+            guard let data = NSData(contentsOfFile: plistPath) as Data?,
+                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] else {
+                return
+            }
+            let allDisabled = daemonLabels.allSatisfy { (plist[$0] as? Bool) == true }
+            if allDisabled {
+                DispatchQueue.main.async {
+                    screenTimeDisabled = true
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue where the OTA Update and Screen Time status was incorrectly shown as Enabled after reinstalling the application.

Instead of relying on the app’s local storage, the app now directly checks the real system state from:

/private/var/db/com.apple.xpc.launchd/disabled.plist

This ensures the correct status is preserved even after the app is deleted and reinstalled.

Changes

- Read OTA Update status from disabled.plist
- Read Screen Time status from disabled.plist
- Fixed incorrect default Enabled state after reinstall
- Removed the unnecessary respring button from:
    - OTAView.swift
    - ScreenTimeView.swift

Result

The UI now always reflects the actual system configuration instead of temporary app storage values.